### PR TITLE
Move logic to MainPage.ProcessLogin

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -113,6 +113,26 @@ public class MainPage : Page
 
         // if (Program.UsesFallbackSteamAppId && this.loginFrame.IsSteam)
         //     throw new Exception("Doesn't own Steam AppId on this account.");
+        if (!Program.Config.IsIgnoringSteam ?? true)
+        {
+            try
+            {
+                var appId = Program.Config.IsFt == true ? Program.STEAM_APP_ID_FT : Program.STEAM_APP_ID;
+                Program.Steam.Initialize(appId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Couldn't init Steam with game AppIds, trying FT");
+                try
+                {
+                    Program.Steam.Initialize(Program.STEAM_APP_ID_FT);
+                }
+                catch (Exception e)
+                {
+                    Log.Error(e, "Steam couldn't load");
+                }
+            }
+        }
 
         Task.Run(async () =>
         {

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -38,7 +38,7 @@ public class SettingsTabGame : SettingsTab
         new SettingsEntry<DpiAwareness>("Game DPI Awareness", "Select the game's DPI Awareness. Change this if the game's scaling looks wrong.", () => Program.Config.DpiAwareness ?? DpiAwareness.Unaware, x => Program.Config.DpiAwareness = x),
         new SettingsEntry<bool>("Free trial account", "Check this if you are using a free trial account.", () => Program.Config.IsFt ?? false, x => Program.Config.IsFt = x),
         new SettingsEntry<bool>("Use XIVLauncher authenticator/OTP macros", "Check this if you want to use the XIVLauncher authenticator app or macros.", () => Program.Config.IsOtpServer ?? false, x => Program.Config.IsOtpServer = x),
-        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam (Requires Restart).", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
+        new SettingsEntry<bool>("Ignore Steam", "Check this if you do not want XIVLauncher to communicate with Steam.", () => Program.Config.IsIgnoringSteam ?? false, x => Program.Config.IsIgnoringSteam = x),
     };
 
     public override string Title => "Game";

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -145,19 +145,6 @@ class Program
                 default:
                     throw new PlatformNotSupportedException();
             }
-            if (!Config.IsIgnoringSteam ?? true)
-            {
-                try
-                {
-                    var appId = Config.IsFt == true ? STEAM_APP_ID_FT : STEAM_APP_ID;
-                    Steam.Initialize(appId);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Couldn't init Steam with game AppIds, trying FT");
-                    Steam.Initialize(STEAM_APP_ID_FT);
-                }
-            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
If we move the Steam.Initialize block to MainPage.ProcessLogin(), we can avoid doing all the steam checking actions until the user actually presses the Login button. There does need to be another try/catch inside the first catch statement, otherwise the program will crash if steam isn't found and IsIgnoringSteam is false.